### PR TITLE
Improve calculation of average and more fail safety

### DIFF
--- a/helm-control
+++ b/helm-control
@@ -27,19 +27,7 @@ void initializeAverages();
 // Switches
 static const int32_t mainSwitchPin = 12; // When this switch is open, the motor signal will be set to 2.5v (idle)
 
-// the setup function runs once when you press reset or power the board
-void setup() {
-  // Setup so we can read the serial port
-#ifdef DEBUG
-  Serial.begin(9600);
-  Serial.println("MCP4725 Test");
-#endif
-  // Make sure to calculate correct sum for the very first sample
-  pinMode(mainSwitchPin, INPUT_PULLUP);
-  dac.begin(0x62);
-  dac.setVoltage(dacValue, false); // Just to be on the safe side
-  initializeAverages();
-}
+
 
 // Range for a 12-bit DAC
 static const int32_t dacMinimum        = 0;
@@ -93,6 +81,20 @@ void initializeAverages() {
   }
   potTotal = averageOver * neutralMidPoint;
   oldestPotIndex = 0;
+}
+
+// the setup function runs once when you press reset or power the board
+void setup() {
+  // Setup so we can read the serial port
+#ifdef DEBUG
+  Serial.begin(9600);
+  Serial.println("MCP4725 Test");
+#endif
+  // Make sure to calculate correct sum for the very first sample
+  pinMode(mainSwitchPin, INPUT_PULLUP);
+  dac.begin(0x62);
+  dac.setVoltage(neutralMidPoint, false); // Just to be on the safe side
+  initializeAverages();
 }
 
 // the loop function runs over and over again forever

--- a/helm-control
+++ b/helm-control
@@ -36,8 +36,8 @@ void setup() {
 #endif
   // Make sure to calculate correct sum for the very first sample
   pinMode(mainSwitchPin, INPUT_PULLUP);
-  //dac.begin(0x62);
-  // dac.setVoltage(dacValue, false); // Just to be on the safe side
+  dac.begin(0x62);
+  dac.setVoltage(dacValue, false); // Just to be on the safe side
   initializeAverages();
 }
 

--- a/helm-control
+++ b/helm-control
@@ -31,7 +31,10 @@ void setup() {
   Serial.begin(9600);
   Serial.println("MCP4725 Test");
 #endif
+  // Make sure to calculate correct sum for the very first sample  
+  pinMode(mainSwitchPin, INPUT_PULLUP);
   dac.begin(0x62);
+  dac.setVoltage(dacValue, false); // Just to be on the safe side
 }
 
 // Range for a 12-bit DAC
@@ -78,8 +81,8 @@ int32_t sampleOver       = 0;
 int32_t smoothedPotValue = 0;
 int32_t oldestPotIndex   = 0;  // This is the array index with the oldest value
 int32_t potTotal         = 0;
-int32_t potLoopCount     = 0;
 int32_t potArray[averageOver];
+
 
 // the loop function runs over and over again forever
 void loop() {
@@ -88,9 +91,12 @@ void loop() {
 
   // Read the helm position potentiometer if the main switch is on
   int32_t sensorValue;
-  if (mainSwitchVal == 0) {
+  if (mainSwitchVal == 1) {
     // Switch is off, force the sensorValue to the middle of the neutral range
     sensorValue = neutralMidPoint;
+    sampleOver = 0;
+    oldestPotIndex = 0;
+    potTotal = 0;
   } else {
     // only read the sensor value if the main switch is on
     sensorValue = analogRead(A0);
@@ -98,32 +104,33 @@ void loop() {
   }
 
   // Smooth out the sensorValue over 'averageOver' samples.
-  potArray[oldestPotIndex] = sensorValue;
-  oldestPotIndex = oldestPotIndex + 1;
-  if (oldestPotIndex >= averageOver) {
-    oldestPotIndex = 0;
-  }
-  potLoopCount = averageOver;
-  if (sampleOver < averageOver){
+
+  if (sampleOver < averageOver){    
+    // Array not yet full
     sampleOver++;
-    potLoopCount = sampleOver;
+
+    // Just sum up all the incoming samples
+    potTotal += sensorValue;
+  } else {
+    // We know that the potTotal is the sum of all values in the array
+    // So the new sum is this sum minus the sample to be replaced plus the new sample.
+    potTotal = potTotal + sensorValue - potArray[oldestPotIndex] ;
   }
-  potTotal = 0;
-  for (byte i = 0; i < potLoopCount; i = i + 1) {
-    potTotal = potTotal + potArray[i];
-  }
-  smoothedPotValue = (int)roundf((float)potTotal / (float)potLoopCount);
-//  Serial.print("Oldest pot Index: [");
-//  Serial.print(oldestPotIndex);
-//  Serial.print("], Sample over: [");
-//  Serial.print(sampleOver);
-//  Serial.print("], loop count: [");
-//  Serial.print(potLoopCount);
-//  Serial.print("], pot total: [");
-//  Serial.print(potTotal);
-//  Serial.print("], smoothed sensor: [");
-//  Serial.print(smoothedPotValue);
-//  Serial.println("]");
+
+  // Replace oldes value
+  potArray[oldestPotIndex] = sensorValue;
+  oldestPotIndex = (oldestPotIndex + 1) % averageOver; // Modulo
+  smoothedPotValue = potTotal / sampleOver;
+  
+  //Serial.print("Oldest pot Index: [");
+  //Serial.print(oldestPotIndex);
+  //Serial.print("], Sample over: [");
+  //Serial.print(sampleOver);
+  //Serial.print("], pot total: [");
+  //Serial.print(potTotal);
+  //Serial.print("], smoothed sensor: [");
+  //Serial.print(smoothedPotValue);
+  //Serial.println("]");
 
   int32_t dacValue = dacNeutral;  // Default to 2.5v
   if (smoothedPotValue <= reverseMinimum)

--- a/helm-control
+++ b/helm-control
@@ -21,6 +21,9 @@ Adafruit_MCP4725 dac;
 // Set this value to 9, 8, 7, 6 or 5 to adjust the resolution
 #define DAC_RESOLUTION   (9)
 
+// Forward declaration of init function
+void initializeAverages();
+
 // Switches
 static const int32_t mainSwitchPin = 12; // When this switch is open, the motor signal will be set to 2.5v (idle)
 
@@ -31,10 +34,11 @@ void setup() {
   Serial.begin(9600);
   Serial.println("MCP4725 Test");
 #endif
-  // Make sure to calculate correct sum for the very first sample  
+  // Make sure to calculate correct sum for the very first sample
   pinMode(mainSwitchPin, INPUT_PULLUP);
-  dac.begin(0x62);
-  dac.setVoltage(dacValue, false); // Just to be on the safe side
+  //dac.begin(0x62);
+  // dac.setVoltage(dacValue, false); // Just to be on the safe side
+  initializeAverages();
 }
 
 // Range for a 12-bit DAC
@@ -69,20 +73,27 @@ static const int32_t reverseSensorSteps = (reverseMinimum - reverseMaximum);
 static const int32_t forwardSensorSteps = (forwardMaximum - forwardMinimum);
 
 // Calculate the nuetral range midpoint
-static const int32_t neutralMidPoint = (reverseMinimum + forwardMinimum)/2;
+static const int32_t neutralMidPoint = (reverseMinimum + forwardMinimum) / 2;
 
 // This is for showing percentages.
 static const int32_t reversePercentSteps = 100 / reverseSensorSteps;
 static const int32_t forwardPercentSteps = 100 / forwardSensorSteps;
 
+uint8_t oldSwitchVal = 1;
 // This is used to know how many samples we have in our rolling average. It's
 // main use is to deal with start-up when we don't yet have a full array.
-int32_t sampleOver       = 0;
 int32_t smoothedPotValue = 0;
 int32_t oldestPotIndex   = 0;  // This is the array index with the oldest value
 int32_t potTotal         = 0;
 int32_t potArray[averageOver];
 
+void initializeAverages() {
+  for (int i = 0; i < averageOver; ++i) {
+    potArray[i] = neutralMidPoint;
+  }
+  potTotal = averageOver * neutralMidPoint;
+  oldestPotIndex = 0;
+}
 
 // the loop function runs over and over again forever
 void loop() {
@@ -92,40 +103,35 @@ void loop() {
   // Read the helm position potentiometer if the main switch is on
   int32_t sensorValue;
   if (mainSwitchVal == 1) {
+    if (oldSwitchVal != mainSwitchVal) {
+      // We went from 0->1      
+      initializeAverages();
+    }
+
     // Switch is off, force the sensorValue to the middle of the neutral range
     sensorValue = neutralMidPoint;
-    sampleOver = 0;
-    oldestPotIndex = 0;
-    potTotal = 0;
   } else {
     // only read the sensor value if the main switch is on
     sensorValue = analogRead(A0);
     sensorValue = constrain(sensorValue, reverseMaximum, forwardMaximum);
   }
-
+  
+  oldSwitchVal = mainSwitchVal;
   // Smooth out the sensorValue over 'averageOver' samples.
 
-  if (sampleOver < averageOver){    
-    // Array not yet full
-    sampleOver++;
 
-    // Just sum up all the incoming samples
-    potTotal += sensorValue;
-  } else {
-    // We know that the potTotal is the sum of all values in the array
-    // So the new sum is this sum minus the sample to be replaced plus the new sample.
-    potTotal = potTotal + sensorValue - potArray[oldestPotIndex] ;
-  }
+  // We know that the potTotal is the sum of all values in the array
+  // So the new sum is this sum minus the sample to be replaced plus the new sample.
+  potTotal = potTotal + sensorValue - potArray[oldestPotIndex] ;
+
 
   // Replace oldes value
   potArray[oldestPotIndex] = sensorValue;
   oldestPotIndex = (oldestPotIndex + 1) % averageOver; // Modulo
-  smoothedPotValue = potTotal / sampleOver;
-  
+  smoothedPotValue = potTotal / averageOver;
+
   //Serial.print("Oldest pot Index: [");
   //Serial.print(oldestPotIndex);
-  //Serial.print("], Sample over: [");
-  //Serial.print(sampleOver);
   //Serial.print("], pot total: [");
   //Serial.print(potTotal);
   //Serial.print("], smoothed sensor: [");
@@ -200,7 +206,7 @@ void loop() {
   }
 
   Serial.println("");
- #endif
+#endif
 
   // Update the DAC
   dacValue = constrain(dacValue, dacMinimum, dacMaximum);


### PR DESCRIPTION
I propose multiple changes here

1) Set the switch to active low and pull up the input pin. This will set the drive to neutral if the switch gets disconnected or fails.
    I feel this is the safer option than having the pin floating without the switch. Of course an external pull-down resistor could achive that  with the original code as well.
2) In order to switch to NEUTRAL immediately if the ermergency switch is flipped, modify the average values so that the switch happens without smoothing.
2) Improve the calculation of the average of the last values. It's not necessary to calculate the sum over and over again. 
    This simplifies the code and speeds up the calculation. Furthermore, since it's only about smoothing, i don't think the we have to bother the poor chip with floating point calculations if not necessary.
3) Initializte the DAC with the neutral value in setup. Not really important but looks like a safe choice to me.

I created this project on WOKWI for you. This allows you to test the code without the need for real hardware. Quite convenient in early stages of development.

Its called [DigimerHelmControl](https://wokwi.com/projects/388912131648950273)

